### PR TITLE
specify yaml loader

### DIFF
--- a/pull_galaxy_config.py
+++ b/pull_galaxy_config.py
@@ -60,7 +60,7 @@ def main():
         parser.print_help()
         exit(1)
 
-    conf = yaml.load(open(args.config,'r'))
+    conf = yaml.load(open(args.config,'r'), Loader=yaml.FullLoader)
 
     key = conf['key_file']
     user = conf['username']

--- a/unused_history_cleanup.py
+++ b/unused_history_cleanup.py
@@ -196,7 +196,7 @@ def main():
         parser.print_help()
         exit(1)
 
-    conf = yaml.load(open(args.config,'r'))
+    conf = yaml.load(open(args.config,'r'), Loader=yaml.FullLoader)
 
     #Connection stuff
     pg_host = conf['pg_host']

--- a/unused_history_cleanup.py
+++ b/unused_history_cleanup.py
@@ -317,7 +317,7 @@ def main():
         conn.close()
 
         for u in user_warns.keys():
-            send_email_to_user(user_warns[u], user_warn_hists[u], warn_threshold, delete_threshold, server_name, smtp_server, from_addr, response_addr, info_url, VERBOSE)
+            send_email_to_user(user_warns[u], user_warn_hists[u], warn_threshold, delete_threshold, server_name, smtp_server, from_addr, response_addr, bcc_addr, info_url, VERBOSE)
     return
 
 


### PR DESCRIPTION
Since PyYAML 5.1 loading a yaml file without specifying a loader raises
a deprecation note:

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  conf = yaml.load(open(args.config,'r'))
```

see also https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

so I suggest to specify the FullLoader (we could also go for another one).